### PR TITLE
SASS deprecation warnings with version 1.77.7

### DIFF
--- a/src/dropzone.scss
+++ b/src/dropzone.scss
@@ -49,6 +49,11 @@
 
   $image-border-radius: 20px;
 
+  min-height: 150px;
+  border: 1px solid rgba(0, 0, 0, 0.8);
+  border-radius: 5px;
+  padding: 20px 20px;
+
   &.dz-clickable {
     cursor: pointer;
 
@@ -62,10 +67,7 @@
     }
   }
 
-  min-height: 150px;
-  border: 1px solid rgba(0, 0, 0, 0.8);
-  border-radius: 5px;
-  padding: 20px 20px;
+  
 
   &.dz-started {
     .dz-message {
@@ -185,11 +187,11 @@
           }
         }
         &:not(:hover) {
+          overflow: hidden;
+          text-overflow: ellipsis;
           span {
             border: 1px solid transparent;
           }
-          overflow: hidden;
-          text-overflow: ellipsis;
         }
 
       }


### PR DESCRIPTION
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.


More info: https://sass-lang.com/d/mixed-decls