### PR TITLE
Improve fallback uuid-generator

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1709,13 +1709,8 @@ export default class Dropzone extends Emitter {
   }
 
   static uuidv4() {
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-      /[xy]/g,
-      function (c) {
-        let r = (Math.random() * 16) | 0,
-          v = c === "x" ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      }
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+      (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
     );
   }
 }


### PR DESCRIPTION
As described in this StackOverflow [answer](https://stackoverflow.com/a/2117523) and detailed in the [following blog post](https://www.bocoup.com/blog/random-numbers), we should avoid using `Math.random` and instead use `crypto.getRandomValues` to ensure uniqueness. 

PS: `crypto.getRandomValues` is available even from insecure contexts. 