### PR TITLE
An oversized file breaks successive files uploads if it is first photo processed for uploading (first dropped into the dropzone)

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -279,13 +279,14 @@ export default class Dropzone extends Emitter {
 
     // Emit a `queuecomplete` event if all files finished uploading.
     this.on("complete", (file) => {
-      if (
+      const _queue_check = () =>
         this.getAddedFiles().length === 0 &&
         this.getUploadingFiles().length === 0 &&
-        this.getQueuedFiles().length === 0
-      ) {
+        this.getQueuedFiles().length === 0;
+      if (_queue_check()) {
         // This needs to be deferred so that `queuecomplete` really triggers after `complete`
-        return setTimeout(() => this.emit("queuecomplete"), 0);
+        // delay 1s and re-check to be sure additional uploads have not been queued after 1st one
+        return setTimeout(() => { if (_queue_check()) this.emit("queuecomplete"); }, 1000);
       }
     });
 


### PR DESCRIPTION
This fixes a bug where if the 1st file dropped into the dropzone was oversized (greater than the maxFilesize) then the successive photos would not properly process.

This was due to the "if" condition here returning "true" when it was the 1st file in the queue and the other files had not yet been "added" to the queue yet.

My fix waits for 1s now and re-checks to be sure the queue is still empty before emitting the "queuecomplete" event.

### Behavior Description
If the first image dropped into the dropzone happens to be too large when compared against the maxFilesize setting, the rest of the files will not properly upload and will not fire a success event because the queuecomplete event gets called too early.

### To Reproduce
To reproduce the behavior:

1. Create event handlers for the success, error and queuecomplete events in your init function used by dropzone.js
2. Set break points at the top of the the success and error event handler code from step 1
3. Drop multiple files into the dropzone - make sure the oversized photo is the first one to process
4. Notice that once the error callback is called once, the success callback never fires for the photos that were not oversized

This does not happen if the oversized photo is 2nd or later in the group of photos to process. It only happens if it is the 1st one to process.