### PR TITLE
add null check to prevent uncaught type error on parent node

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -211,7 +211,7 @@ export default class Dropzone extends Emitter {
     if (this.clickableElements.length) {
       let setupHiddenFileInput = () => {
         if (this.hiddenFileInput) {
-          this.hiddenFileInput.parentNode.removeChild(this.hiddenFileInput);
+          this.hiddenFileInput.parentNode?.removeChild(this.hiddenFileInput);
         }
         this.hiddenFileInput = document.createElement("input");
         this.hiddenFileInput.setAttribute("type", "file");


### PR DESCRIPTION
This fix prevents uncaught type errors thrown if `hiddenFileInput` has no `parentNode`.