### PR TITLE
Bugfix: Unable to disable the Cancel Upload Confirmation window

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -633,10 +633,14 @@ let defaultOptions = {
         e.preventDefault();
         e.stopPropagation();
         if (file.status === Dropzone.UPLOADING) {
-          return Dropzone.confirm(
-            this.options.dictCancelUploadConfirmation,
-            () => this.removeFile(file)
-          );
+          if (this.options.dictCancelUploadConfirmation) {
+            return Dropzone.confirm(
+              this.options.dictCancelUploadConfirmation,
+              () => this.removeFile(file)
+            );
+          } else {
+            return this.removeFile(file);
+          }
         } else {
           if (this.options.dictRemoveFileConfirmation) {
             return Dropzone.confirm(


### PR DESCRIPTION
**Describe the bug**
Unable to disable the Cancel Upload Confirmation window.

**To Reproduce**
Steps to reproduce the behavior:
1. Create a dropzone form with the following option:
```
   dictCancelUploadConfirmation: ""
```
2. Start uploading a very large file.
4. Click on Cancel Upload.
5. A blank confirmation window appears.

**Expected behavior**
At step 5 I'm expecting for the upload to be immediately cancelled, without the confirmation window appearing.